### PR TITLE
chore: add .gitattributes to help gh-linguist identify c++

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hh linguist-language=C++


### PR DESCRIPTION
# Description

GitHub uses the tool Linguist to identify which language is use for a work. It has some known problems (look through old and new issues in the project)  regarding identifying correct headers from the C-langs families - C, Objectiv-C and C++ etc ,header files and linguist needs a little help.

This PR adds a .gitattributes file that contains an explict declaration of hh files as C++.

## Type of change

## How Has This Been Tested?
In practice -
Have a look in the fork of this pr, under the main branch under "languages and one can see that C++ is identified correctly. Note, do a webbrowser side load refresh, i noticed at least my browser cached the languages field when skipping between the main project and the fork
 
## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [X] have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

