### PR TITLE
Add support for specifying input format options on commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ For example, to compare an interlaced source with a transcoded and deinterlaced 
 Vivict++ can display VMAF data if such is provided by using the `--left-vmaf` and/or `--right-vmaf`
 options. The command line options take a path to a csv-file containing the data as argument. The file is expected to be a csv-file created by the [FFmpeg libvmaf filter](http://ffmpeg.org/ffmpeg-filters.html#libvmaf) with `log_fmt=csv`.
 
+### Specifying input format
+In case your input file is in a format this not easily identified, ie raw video, you can use the `--left-format` and `--right-format` to tell vivictpp how to interpret the input file. These options should be followed by a colon-separated list of key=value pairs. If `format` is specified as key, the corresponding value will be passed to [av_find_input_format](https://ffmpeg.org/doxygen/2.8/group__lavf__decoding.html#ga7d2f532c6653c2419b17956712fdf3da) to find the correct input format. Any other key value pairs will be passed to [avformat_open_input](https://ffmpeg.org/doxygen/2.8/group__lavf__decoding.html#ga10a404346c646e4ab58f4ed798baca32) through the `options` parameter.
+
+Example for playing a file containing raw video data:
+
+    vivictpp --left-format format=rawvideo:pixel_format=yuv422p10:video_size=1280x720:framerate=50 my-file.yuv
+
 ### Logging
 
 Logging for debugging purposes can be enabled by setting the environment variable `SPDLOG_LEVEL` to `DEBUG` or even `TRACE`.

--- a/include/SourceConfig.hh
+++ b/include/SourceConfig.hh
@@ -11,16 +11,21 @@
 
 class SourceConfig {
 public:
-  SourceConfig(std::string path, std::string filter = "", std::string vmafLogFile = ""):
+  SourceConfig(std::string path,
+               std::string filter = "",
+               std::string vmafLogFile = "",
+               std::string formatOptions = ""):
     path(path),
     filter(filter),
-    vmafLog(vmafLogFile)
+    vmafLog(vmafLogFile),
+    formatOptions(formatOptions)
     {
     }
 
   const std::string path;
   const std::string filter;
   const vivictpp::vmaf::VmafLog vmafLog;
+  const std::string formatOptions;
 };
 
 #endif  // SOURCECONFIG_HH_

--- a/include/libav/FormatHandler.hh
+++ b/include/libav/FormatHandler.hh
@@ -24,7 +24,7 @@ namespace libav {
 
 class FormatHandler {
 public:
-  explicit FormatHandler(std::string inputFile);
+  explicit FormatHandler(std::string inputFile, std::string formatOptions = "");
   ~FormatHandler();
   const std::vector<AVStream *> &getVideoStreams() const {
     return videoStreams;

--- a/include/workers/PacketWorker.hh
+++ b/include/workers/PacketWorker.hh
@@ -17,7 +17,7 @@ namespace workers {
 
 class PacketWorker : public InputWorker<int> {
 public:
-  PacketWorker(std::string source);
+  PacketWorker(std::string source, std::string format = "");
   virtual ~PacketWorker();
   void addDecoderWorker(const std::shared_ptr<DecoderWorker> &decoderWorker);
   void removeDecoderWorker(const std::shared_ptr<DecoderWorker> &decoderWorker);

--- a/src/VideoInputs.cc
+++ b/src/VideoInputs.cc
@@ -10,10 +10,10 @@ VideoInputs::VideoInputs(VivictPPConfig vivictPPConfig):
   _leftFrameOffset(0),
   leftPtsOffset(0),
   logger(vivictpp::logging::getOrCreateLogger("VideoInputs")) {
-  av_log_set_level(AV_LOG_QUIET);
+  av_log_set_level(AV_LOG_INFO);
   for (auto source: vivictPPConfig.sourceConfigs) {
     auto packetWorker = std::shared_ptr<vivictpp::workers::PacketWorker>(
-      new vivictpp::workers::PacketWorker(source.path));
+      new vivictpp::workers::PacketWorker(source.path, source.formatOptions));
     packetWorkers.push_back(packetWorker);
     if (!packetWorker->getVideoStreams().empty()) {
       if (!leftInput.decoder) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,6 +77,11 @@ int main(int argc, char **argv) {
     app.add_option("--left-vmaf", leftVmaf, "Path to csv-file containing vmaf data for left video");
     app.add_option("--right-vmaf", rightVmaf, "Path to csv-file containing vmaf data for right video");
 
+    std::string leftInputFormat;
+    std::string rightInputFormat;
+    app.add_option("--left-format", leftInputFormat, "Format options for left video input");
+    app.add_option("--right-format", rightInputFormat, "Format options for right video input");
+
     CLI11_PARSE(app, argc, argv);
 
     std::vector<std::string> sources = {leftVideo};
@@ -85,6 +90,7 @@ int main(int argc, char **argv) {
     }
     std::vector<std::string> filters = {leftFilter, rightFilter};
     std::vector<std::string> vmafLogfiles = {leftVmaf, rightVmaf};
+    std::vector<std::string> formatOptions = {leftInputFormat, rightInputFormat};
 
     vivictpp::logging::initializeLogging();
 
@@ -92,7 +98,8 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i<sources.size(); i++) {
         std::string filter = i < filters.size() ? filters[i] : "";
         std::string vmafLogFile = i < vmafLogfiles.size() ? vmafLogfiles[i] : "";
-        sourceConfigs.push_back(SourceConfig(sources[i], filter, vmafLogFile));
+        std::string format = i < formatOptions.size() ? formatOptions[i] : "";
+        sourceConfigs.push_back(SourceConfig(sources[i], filter, vmafLogFile, format));
     }
 
     for (auto sourceConfig : sourceConfigs) {

--- a/src/workers/PacketWorker.cc
+++ b/src/workers/PacketWorker.cc
@@ -5,10 +5,10 @@
 #include "workers/PacketWorker.hh"
 #include "spdlog/spdlog.h"
 
-vivictpp::workers::PacketWorker::PacketWorker(std::string source):
+vivictpp::workers::PacketWorker::PacketWorker(std::string source, std::string format):
     InputWorker<int>(0, "PacketWorker"),
-  formatHandler(source),
-  currentPacket(nullptr)
+    formatHandler(source, format),
+    currentPacket(nullptr)
 {
     for (auto const &videoStream : formatHandler.getVideoStreams()) {
     VideoMetadata m =


### PR DESCRIPTION
The --left-format and --right-format options can now be used to tell vivictpp how to interpret the input files. These options should be followed by a colon-separated list of key=value pairs. If format is specified as key, the corresponding value will be passed to av_find_input_format to find the correct input format. Any other key value pairs will be passed to avformat_open_input through the options parameter.

Example for playing a file containing raw video data:
vivictpp --left-format format=rawvideo:pixel_format=yuv422p10:video_size=1280x720:framerate=50 my-file.yuv

Signed-off-by: Gustav Grusell <gustav.grusell@svt.se>
