### PR TITLE
Add run-time dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ brew install vivictpp
 
 $ apt-get --fix-missing install -y cmake python3-pip gcc python3-setuptools \
   python3-wheel libsdl2-dev libsdl2-ttf-dev libfreetype6-dev libavformat-dev libavcodec-dev \
-  libswscale-dev pkg-config
+  libavfilter-dev libswscale-dev pkg-config
 
 ```
 


### PR DESCRIPTION


# Pull Request Template

## Description

`meson builddir` failed for me without having libavfilter-dev installed.

## Type of change

Documentation only

## How Has This Been Tested?

I was able to build using the instructions after installing this additional package.

## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

(I did not conduct all of these tests due to this being a trivial documentation-only PR.)